### PR TITLE
allow extendObject and delObject without allowAdmin flag

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -193,7 +193,7 @@ function IOSocket(server, settings, adapter) {
     this.getWhiteListIpForAddress = function (address, whiteList){
         return getWhiteListIpForAddress(address, whiteList);
     };
-    
+
     function getWhiteListIpForAddress(address, whiteList) {
         if (!whiteList) return null;
 
@@ -897,7 +897,7 @@ function IOSocket(server, settings, adapter) {
                 }
             }
         });
-        
+
         socket.on('getObjectView', function (design, search, params, callback) {
             if (updateSession(socket) && checkPermissions(socket, 'getObjectView', callback, search)) {
                 that.adapter.getObjectView(design, search, params, {user: socket._acl.user}, callback);
@@ -907,6 +907,18 @@ function IOSocket(server, settings, adapter) {
         socket.on('setObject', function (id, obj, callback) {
             if (updateSession(socket) && checkPermissions(socket, 'setObject', callback, id)) {
                 that.adapter.setForeignObject(id, obj, {user: socket._acl.user}, callback);
+            }
+        });
+
+        socket.on('delObject', function (id, callback) {
+            if (updateSession(socket) && checkPermissions(socket, 'delObject', callback, id)) {
+                that.adapter.delForeignObject(id, {user: socket._acl.user}, callback);
+            }
+        });
+
+        socket.on('extendObject', function (id, obj, callback) {
+            if (updateSession(socket) && checkPermissions(socket, 'extendObject', callback, id)) {
+                that.adapter.extendForeignObject(id, obj, {user: socket._acl.user}, callback);
             }
         });
 
@@ -963,16 +975,6 @@ function IOSocket(server, settings, adapter) {
                 }
             });
 
-            socket.on('delObject', function (id, callback) {
-                if (updateSession(socket) && checkPermissions(socket, 'delObject', callback, id)) {
-                    that.adapter.delForeignObject(id, {user: socket._acl.user}, callback);
-                }
-            });
-            socket.on('extendObject', function (id, obj, callback) {
-                if (updateSession(socket) && checkPermissions(socket, 'extendObject', callback, id)) {
-                    that.adapter.extendForeignObject(id, obj, {user: socket._acl.user}, callback);
-                }
-            });
             socket.on('getHostByIp', function (ip, callback) {
                 if (updateSession(socket) && checkPermissions(socket, 'getHostByIp', ip)) {
                     that.adapter.getObjectView('system', 'host', {}, {user: socket._acl.user}, function (err, data) {
@@ -1103,19 +1105,6 @@ function IOSocket(server, settings, adapter) {
                     }
                     if (typeof callback === 'function') {
                         callback(result.error, result.list);
-                    }
-                }
-            });
-        } else {
-            // only flot allowed
-            socket.on('delObject', function (id, callback) {
-                if (id.match(/^flot\./)) {
-                    if (updateSession(socket) && checkPermissions(socket, 'delObject', callback, id)) {
-                        that.adapter.delForeignObject(id, {user: socket._acl.user}, callback);
-                    }
-                } else {
-                    if (typeof callback === 'function') {
-                        callback('permissionError');
                     }
                 }
             });


### PR DESCRIPTION
- fixes #34 
- does it make sense to not allow it in socketio? permissions seem to be checked additionally for the confiured user in `checkPermissions` also `setObject` is allowed w.o. `allowAdmin` settings, but `extendObject` and `delObject` not - it does not really make sense from my pov