### PR TITLE
Fix type of global var states

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -15,7 +15,7 @@
     servConn.namespace   = 'mobile.0';
     servConn._useStorage = false;
 
-    var states = [];
+    var states = {};
     servConn.init({
         name:          'mobile.0',  // optional - default 'vis.0'
         connLink:      'http://localhost:8084',  // optional URL of the socket.io adapter


### PR DESCRIPTION
In the example index.html a global var named "states" is defined to collect states from the underlying iobroker host. Unfortunately it is defined with an empty array which will later be overwritten with an resulting object as returned by the callback of "servConn.getStates". As this is an example the type should be correct.